### PR TITLE
Fix MIME type error by using routes instead of rewrites in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,10 +2,13 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite",
-  "rewrites": [
+  "routes": [
     {
-      "source": "/(.*)",
-      "destination": "/index.html"
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolves incorrect 404s on deep links by routing unmatched paths to the app shell.
  * Ensures client-side navigation works reliably across refreshes and shared URLs.
  * Preserves direct access to static assets via filesystem handling for predictable loading.

* **Chores**
  * Migrates deployment routing to a routes-based configuration for improved compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->